### PR TITLE
warrior-install.sh: use pip3 if available

### DIFF
--- a/warrior-install.sh
+++ b/warrior-install.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
 
+PIP=pip
+
+if type pip3 > /dev/null 2>&1
+then
+  PIP=pip3
+fi
+
 echo "Installing warcio"
-if ! sudo pip install warcio --upgrade
+if ! sudo $PIP install warcio --upgrade
 then
   exit 1
 fi


### PR DESCRIPTION
The standard Warrior Docker image comes with both Python2 and Python3,
with separate pip and pip3 binaries, respectively. Because it runs the
Warrior using Python3, installing warcio using pip in warrior-install.sh
will not make it available to the grabber. This change fixes this by
using pip3 if it is available.